### PR TITLE
Add colorName method to the Recipe class

### DIFF
--- a/src/recipe.coffee
+++ b/src/recipe.coffee
@@ -144,6 +144,10 @@ class Brauhaus.Recipe extends Brauhaus.OptionConstructor
     bottleCount: ->
         Math.floor(@batchSize / @servingSize)
 
+    # Get a friendly human-readable color name
+    colorName: ->
+        Brauhaus.srmToName @color
+
     # Scale this recipe, keeping gravity and bitterness the same
     scale: (batchSize, boilSize) ->
         earlyOg = 1.0

--- a/test/recipe.coffee
+++ b/test/recipe.coffee
@@ -82,6 +82,9 @@ describe 'Recipe', ->
         it 'Should calculate color as 4.6 SRM', ->
             assert.equal 4.6, recipe.color.toFixed(1)
 
+        it 'Should calculate colorName as yellow', ->
+            assert.equal 'yellow', recipe.colorName()
+
         it 'Should calculate calories as 165 kcal', ->
             assert.equal 165, Math.round(recipe.calories)
 


### PR DESCRIPTION
This method is used in the README, but didn't exist.

I haven't included the changes to `dist/brauhaus.min.js` in this pull request, but I can do if needed.

Thanks for the great software! :beer: 

Fixes #3
